### PR TITLE
Generalize TSIG keys and also CNAME and DNAME

### DIFF
--- a/draft-axu-dnsop-catalog-zone-xfr-properties.md
+++ b/draft-axu-dnsop-catalog-zone-xfr-properties.md
@@ -258,7 +258,7 @@ An APL RRset containing more that a single APL RR, MUST be interpreted as an APL
 The `allow-transfer` property MAY also have a TXT RRset, which will (further) restrict the zone to be transferable only with the TSIG key indicated in any of the TXT RRs in the set.
 The key(s) MUST be defined elsewhere, such as in the configuration file of the consumer.
 A TXT RRset for a `allow-transfer` property containing more than a single TXT RR indicates a broken catalog zone that MUST NOT be processed (see {{Section 5.1 of !RFC9432}}).
-If an TXT RRset is present together with an APL RR, then first the policies in the APL are applied, and if that results in transfers being allowed for the IP address, then in addition a TSIG key MUST match any of the TXT RRs in the TXT RRset.
+If a TXT RRset is present together with an APL RR, then first the policies in the APL are applied, and if that results in transfers being allowed for the IP address, then in addition a TSIG key MUST match any of the TXT RRs in the TXT RRset.
 If an TXT RRset is present without an APL RRset, then only a TSIG key MUST match in any of the TXT RRs in the TXT RRset, regardless of the querying IP address.
 
 If an `allow-transfer` property is present *and* contains APL RRsets and/or TXT RRsets (either directly below the property label or below the additional label), *and* none of the APLs and/or TSIG keys matched or could be found, then the consumer MUST NOT allow transfers of the member zone to which the property applies.

--- a/draft-axu-dnsop-catalog-zone-xfr-properties.md
+++ b/draft-axu-dnsop-catalog-zone-xfr-properties.md
@@ -81,6 +81,8 @@ informative:
 
 This document specifies DNS Catalog Zones Properties that define the primary name servers from which specific or all member zones can transfer their associated zone, as well as properties related to zone transfers such as access control.
 
+Besides the additional properties, this document updates RFC9432 by explicitly allowing CNAMEs and DNAMEs.
+
 --- middle
 
 # Introduction

--- a/draft-axu-dnsop-catalog-zone-xfr-properties.md
+++ b/draft-axu-dnsop-catalog-zone-xfr-properties.md
@@ -191,7 +191,7 @@ An additional label below the property name MAY be used to distinguish different
 The `notify` property, with or without the extra label, MAY also have a TXT RRset, which MUST consist of a single TXT RR, which will contain the name of the TSIG key to use to sign the NOTIFY message.
 The key(s) MUST be defined elsewhere, such as in the configuration file of the consumer.
 If the key cannot be found, the consumer MUST NOT notify the name server addresses for which the key was an additional attribute.
-If the TXT RRset contains more than a single TXT RR, the consumer MUST NOT notify the name server addresses for which the key was an additional attribute.
+A TXT RRset for a `notify` property containing more than a single TXT RR indicates a broken catalog zone that MUST NOT be processed (see {{Section 5.1 of !RFC9432}}).
 
 ~~~ ascii-art
 notify.$CATZ                      0 IN A 192.0.2.49

--- a/draft-axu-dnsop-catalog-zone-xfr-properties.md
+++ b/draft-axu-dnsop-catalog-zone-xfr-properties.md
@@ -220,7 +220,7 @@ The prefixes listed in the APL RR are processed in order:
 The absence of an `allow-query` property at both apex of the catalog as well as at a member zone, means that the default policy applies, which may be that the member zone is allowed to be queried from any IP address without TSIG key.
 
 Additional attributes (such as TSIG keys) can be bound to specific APL RRs by an additional label below the property label.
-The prefixes(with or without attributes) will be processed in {{Section 6 of !RFC4034 (canonical order)}}, which means that the RRsets at the `allow-query` property label will be processed first, followed by the RRsets with the additional label in canonical order.
+The prefixes (with or without attributes) will be processed in {{Section 6 of !RFC4034 (canonical order)}}, which means that the RRsets at the `allow-query` property label will be processed first, followed by the RRsets with the additional label in canonical order.
 An APL RRset containing more that a single APL RR, MUST be interpreted as an APL RRset containing a single APL RR denying all IP addresses, i.e.: `APL !1:0.0.0.0/0 !2:0:0:0:0:0:0:0:0/0`.
 
 ### TSIG Key Name

--- a/draft-axu-dnsop-catalog-zone-xfr-properties.md
+++ b/draft-axu-dnsop-catalog-zone-xfr-properties.md
@@ -259,7 +259,7 @@ The `allow-transfer` property MAY also have a TXT RRset, which will (further) re
 The key(s) MUST be defined elsewhere, such as in the configuration file of the consumer.
 A TXT RRset for a `allow-transfer` property containing more than a single TXT RR indicates a broken catalog zone that MUST NOT be processed (see {{Section 5.1 of !RFC9432}}).
 If a TXT RRset is present together with an APL RR, then first the policies in the APL are applied, and if that results in transfers being allowed for the IP address, then in addition a TSIG key MUST match any of the TXT RRs in the TXT RRset.
-If an TXT RRset is present without an APL RRset, then only a TSIG key MUST match in any of the TXT RRs in the TXT RRset, regardless of the querying IP address.
+If a TXT RRset is present without an APL RRset, then only a TSIG key MUST match in any of the TXT RRs in the TXT RRset, regardless of the querying IP address.
 
 If an `allow-transfer` property is present *and* contains APL RRsets and/or TXT RRsets (either directly below the property label or below the additional label), *and* none of the APLs and/or TSIG keys matched or could be found, then the consumer MUST NOT allow transfers of the member zone to which the property applies.
 

--- a/draft-axu-dnsop-catalog-zone-xfr-properties.md
+++ b/draft-axu-dnsop-catalog-zone-xfr-properties.md
@@ -221,7 +221,7 @@ The absence of an `allow-query` property at both apex of the catalog as well as 
 
 Additional attributes (such as TSIG keys) can be bound to specific APL RRs by an additional label below the property label.
 The prefixes (with or without attributes) will be processed in {{Section 6 of !RFC4034 (canonical order)}}, which means that the RRsets at the `allow-query` property label will be processed first, followed by the RRsets with the additional label in canonical order.
-An APL RRset containing more that a single APL RR, MUST be interpreted as an APL RRset containing a single APL RR denying all IP addresses, i.e.: `APL !1:0.0.0.0/0 !2:0:0:0:0:0:0:0:0/0`.
+When a catalog consumer encounters an APL RRset containing more that a single APL RR, MUST be interpreted as an APL RRset containing a single APL RR denying all IP addresses, i.e.: `APL !1:0.0.0.0/0 !2:0:0:0:0:0:0:0:0/0`.
 
 ### TSIG Key Name
 
@@ -251,7 +251,7 @@ The prefixes listed in the APL are processed in order:
 The absence of an `allow-transfer` property at both apex of the catalog as well as at a member zone, signifies that transfers of the zone from the consumer MUST NOT be allowed.
 Additional attributes (such as TSIG keys) can be bound to specific APL RRs by an additional label below the property label.
 The prefixes (with or without attributes) will be processed in {{Section 6 of !RFC4034 (canonical order)}}, which means that the RRsets at the `allow-transfer` property label will be processed first, followed by the RRsets with the additional label in canonical order.
-An APL RRset containing more that a single APL RR, MUST be interpreted as an APL RRset containing a single APL RR denying all IP addresses, i.e.: `APL !1:0.0.0.0/0 !2:0:0:0:0:0:0:0:0/0`.
+When a catalog consumer encounters an APL RRset containing more that a single APL RR, MUST be interpreted as an APL RRset containing a single APL RR denying all IP addresses, i.e.: `APL !1:0.0.0.0/0 !2:0:0:0:0:0:0:0:0/0`.
 
 ### TSIG Key Name
 

--- a/draft-axu-dnsop-catalog-zone-xfr-properties.md
+++ b/draft-axu-dnsop-catalog-zone-xfr-properties.md
@@ -225,9 +225,8 @@ When a catalog consumer encounters an APL RRset containing more that a single AP
 
 ### TSIG Key Name
 
-The `allow-query` property MAY also have a TXT RRset, which will (further) restrict the zone to be queryable only with the TSIG key indicated in any of the TXT RRs in the set.
+The `allow-query` property MAY also have a TXT RRset, which will (further) restrict the zone to be queryable only with the TSIG keys indicated in any of the TXT RRs in the set.
 The key(s) MUST be defined elsewhere, such as in the configuration file of the consumer.
-A TXT RRset for a `allow-query` property containing more than a single TXT RR indicates a broken catalog zone that MUST NOT be processed (see {{Section 5.1 of !RFC9432}}).
 
 If a TXT RRset is present together with an APL RR, then first the policies in the APL are applied, and if that results in queries being allowed for the IP address, then in addition a TSIG key MUST match any of the TXT RRs in the TXT RRset.
 If a TXT RRset is present without an APL RRset, then only a TSIG key MUST match in any of the TXT RRs in the TXT RRset, regardless of the querying IP address.
@@ -257,7 +256,6 @@ When a catalog consumer encounters an APL RRset containing more that a single AP
 
 The `allow-transfer` property MAY also have a TXT RRset, which will (further) restrict the zone to be transferable only with the TSIG key indicated in any of the TXT RRs in the set.
 The key(s) MUST be defined elsewhere, such as in the configuration file of the consumer.
-A TXT RRset for a `allow-transfer` property containing more than a single TXT RR indicates a broken catalog zone that MUST NOT be processed (see {{Section 5.1 of !RFC9432}}).
 If a TXT RRset is present together with an APL RR, then first the policies in the APL are applied, and if that results in transfers being allowed for the IP address, then in addition a TSIG key MUST match any of the TXT RRs in the TXT RRset.
 If a TXT RRset is present without an APL RRset, then only a TSIG key MUST match in any of the TXT RRs in the TXT RRset, regardless of the querying IP address.
 

--- a/draft-axu-dnsop-catalog-zone-xfr-properties.md
+++ b/draft-axu-dnsop-catalog-zone-xfr-properties.md
@@ -250,7 +250,7 @@ The prefixes listed in the APL are processed in order:
 
 The absence of an `allow-transfer` property at both apex of the catalog as well as at a member zone, signifies that transfers of the zone from the consumer MUST NOT be allowed.
 Additional attributes (such as TSIG keys) can be bound to specific APL RRs by an additional label below the property label.
-The prefixes(with or without attributes) will be processed in {{Section 6 of !RFC4034 (canonical order)}}, which means that the RRsets at the `allow-transfer` property label will be processed first, followed by the RRsets with the additional label in canonical order.
+The prefixes (with or without attributes) will be processed in {{Section 6 of !RFC4034 (canonical order)}}, which means that the RRsets at the `allow-transfer` property label will be processed first, followed by the RRsets with the additional label in canonical order.
 An APL RRset containing more that a single APL RR, MUST be interpreted as an APL RRset containing a single APL RR denying all IP addresses, i.e.: `APL !1:0.0.0.0/0 !2:0:0:0:0:0:0:0:0/0`.
 
 ### TSIG Key Name

--- a/draft-axu-dnsop-catalog-zone-xfr-properties.md
+++ b/draft-axu-dnsop-catalog-zone-xfr-properties.md
@@ -255,7 +255,7 @@ An APL RRset containing more that a single APL RR, MUST be interpreted as an APL
 
 The `allow-transfer` property MAY also have a TXT RRset, which will (further) restrict the zone to be transferable only with the TSIG key indicated in any of the TXT RRs in the set.
 The key(s) MUST be defined elsewhere, such as in the configuration file of the consumer.
-
+A TXT RRset for a `allow-transfer` property containing more than a single TXT RR indicates a broken catalog zone that MUST NOT be processed (see {{Section 5.1 of !RFC9432}}).
 If an TXT RRset is present together with an APL RR, then first the policies in the APL are applied, and if that results in transfers being allowed for the IP address, then in addition a TSIG key MUST match any of the TXT RRs in the TXT RRset.
 If an TXT RRset is present without an APL RRset, then only a TSIG key MUST match in any of the TXT RRs in the TXT RRset, regardless of the querying IP address.
 

--- a/draft-axu-dnsop-catalog-zone-xfr-properties.md
+++ b/draft-axu-dnsop-catalog-zone-xfr-properties.md
@@ -229,7 +229,7 @@ The `allow-query` property MAY also have a TXT RRset, which will (further) restr
 The key(s) MUST be defined elsewhere, such as in the configuration file of the consumer.
 A TXT RRset for a `allow-query` property containing more than a single TXT RR indicates a broken catalog zone that MUST NOT be processed (see {{Section 5.1 of !RFC9432}}).
 
-If an TXT RRset is present together with an APL RR, then first the policies in the APL are applied, and if that results in queries being allowed for the IP address, then in addition a TSIG key MUST match any of the TXT RRs in the TXT RRset.
+If a TXT RRset is present together with an APL RR, then first the policies in the APL are applied, and if that results in queries being allowed for the IP address, then in addition a TSIG key MUST match any of the TXT RRs in the TXT RRset.
 If an TXT RRset is present without an APL RRset, then only a TSIG key MUST match in any of the TXT RRs in the TXT RRset, regardless of the querying IP address.
 
 If an `allow-query` property is present *and* contains APL RRsets and/or TXT RRsets (either directly below the property label or below the additional label), *and* none of the ACLs and/or TSIG keys matched or could be found, then the consumer MUST NOT allow queries for the member zone to which the property applies.

--- a/draft-axu-dnsop-catalog-zone-xfr-properties.md
+++ b/draft-axu-dnsop-catalog-zone-xfr-properties.md
@@ -225,6 +225,7 @@ An APL RRset containing more that a single APL RR, MUST be interpreted as an APL
 
 The `allow-query` property MAY also have a TXT RRset, which will (further) restrict the zone to be queryable only with the TSIG key indicated in any of the TXT RRs in the set.
 The key(s) MUST be defined elsewhere, such as in the configuration file of the consumer.
+A TXT RRset for a `allow-query` property containing more than a single TXT RR indicates a broken catalog zone that MUST NOT be processed (see {{Section 5.1 of !RFC9432}}).
 
 If an TXT RRset is present together with an APL RR, then first the policies in the APL are applied, and if that results in queries being allowed for the IP address, then in addition a TSIG key MUST match any of the TXT RRs in the TXT RRset.
 If an TXT RRset is present without an APL RRset, then only a TSIG key MUST match in any of the TXT RRs in the TXT RRset, regardless of the querying IP address.

--- a/draft-axu-dnsop-catalog-zone-xfr-properties.md
+++ b/draft-axu-dnsop-catalog-zone-xfr-properties.md
@@ -271,7 +271,7 @@ ZONELABEL5.zones.$CATZ  0                IN PTR example.local.
 
 # Implementation and Operational Notes
 
-The rationale for allowing CNAMEs for access lists is that a large and complex catalog may have large and complex access lists repeated a million times. But if there are only a few different access lists, they could be defined separately and then be referenced a million times, reducing both the size and processing effort of the catalog zone.
+One of the rationales for allowing CNAMEs and DNAMEs is that a large and complex catalog may have large and complex access lists repeated a million times. But if there are only a few different access lists, they could be defined separately and then be referenced a million times, reducing both the size and processing effort of the catalog zone.
 
 # IANA Considerations {#IANA}
 

--- a/draft-axu-dnsop-catalog-zone-xfr-properties.md
+++ b/draft-axu-dnsop-catalog-zone-xfr-properties.md
@@ -230,7 +230,7 @@ The key(s) MUST be defined elsewhere, such as in the configuration file of the c
 A TXT RRset for a `allow-query` property containing more than a single TXT RR indicates a broken catalog zone that MUST NOT be processed (see {{Section 5.1 of !RFC9432}}).
 
 If a TXT RRset is present together with an APL RR, then first the policies in the APL are applied, and if that results in queries being allowed for the IP address, then in addition a TSIG key MUST match any of the TXT RRs in the TXT RRset.
-If an TXT RRset is present without an APL RRset, then only a TSIG key MUST match in any of the TXT RRs in the TXT RRset, regardless of the querying IP address.
+If a TXT RRset is present without an APL RRset, then only a TSIG key MUST match in any of the TXT RRs in the TXT RRset, regardless of the querying IP address.
 
 If an `allow-query` property is present *and* contains APL RRsets and/or TXT RRsets (either directly below the property label or below the additional label), *and* none of the ACLs and/or TSIG keys matched or could be found, then the consumer MUST NOT allow queries for the member zone to which the property applies.
 

--- a/draft-axu-dnsop-catalog-zone-xfr-properties.md
+++ b/draft-axu-dnsop-catalog-zone-xfr-properties.md
@@ -290,7 +290,7 @@ IANA is requested to add the following entries to the "DNS Catalog Zones Propert
 
 This section records the status of known implementations of the protocol defined by this specification at the time of posting of this Internet-Draft {{?RFC7942}}.
 
-The existing Bind9 implementation of `primaries`, `allow-transfer` and `allow-query` was a major inspiration for writing this draft.
+The existing BIND 9 implementation of `primaries`, `allow-transfer` and `allow-query` was a major inspiration for writing this draft.
 
 # Security and Privacy Considerations
 

--- a/draft-axu-dnsop-catalog-zone-xfr-properties.md
+++ b/draft-axu-dnsop-catalog-zone-xfr-properties.md
@@ -148,7 +148,7 @@ If there are any RRs attached to the `primaries` that are not covered by this do
 
 The `primaries` property, with or without the extra label, MAY also have a TXT resource record set (RRset), which MUST consist of a single TXT RR, which will contain the name of the TSIG key to use to protect zone transfers. The key(s) MUST be defined elsewhere, such as in the configuration file of the consumer.
 If the key cannot be found, the consumer MUST NOT attempt a zone transfer from the name server addresses for which the TXT RRset was an additional attribute.
-If the TXT RRset contains more than a single TXT RR, the consumer MUST NOT attempt a zone transfer from the name server addresses for which the TXT RRset was an additional attribute.
+A TXT RRset for a `primaries` property containing more than a single TXT RR indicates a broken catalog zone that MUST NOT be processed (see {{Section 5.1 of !RFC9432}}).
 
 ~~~ ascii-art
 ZONELABEL2.zones.$CATZ  0                IN PTR example.net.


### PR DESCRIPTION
This PR generalizes TSIG to be usable similarly for all the new properties.
It furthermore generalizes CNAME and DNAME to be used anywhere in the catalog.